### PR TITLE
Simplify gradle file, add support for suffix tags

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ import org.asciidoctor.gradle.jvm.pdf.AsciidoctorPdfTask
 import java.text.ParseException
 import java.text.SimpleDateFormat
 
-
 plugins {
     id 'application'
     id 'org.asciidoctor.jvm.convert' version '4.0.3'
@@ -15,34 +14,29 @@ repositories {
     mavenCentral()
 }
 
+pdfThemes {
+    local 'isaqb', {
+        themeDir = file("../pdf-theme/themes")
+        themeName = 'isaqb'
+    }
+}
+
 ext {
     workDirectory = rootProject.projectDir
-    def releaseVersion = System.getenv("RELEASE_VERSION")
-    def localVersion = "LocalBuild"
-    def curriculumFileName = rootProject.curriculumFileName
-
-    // We can only set a value for validity if it was set in the parent gradle file.
-    validity = null
-    if (rootProject.hasProperty("validity")) {
-        validity = rootProject.validity
-    }
-
-
-    project.version = releaseVersion == null ? localVersion : releaseVersion
+    project.version = System.getenv("RELEASE_VERSION") ?: "LocalBuild"
     versionDate = new SimpleDateFormat("yyyyMMdd").format(new Date())
+    curriculumFileName = rootProject.curriculumFileName
+    validity = rootProject.findProperty("validity")
+    languages = rootProject.findProperty("languages") ?: ["DE", "EN"]
+    suffixTags = rootProject.findProperty("suffixTags") ? rootProject.suffixTags : [""]
 }
 
 static def formatValidity(validity, language) {
     if (validity) {
         try {
-            def parsedValidity = new SimpleDateFormat("yyyy/MM/dd", Locale.US).parse((String) validity)
-
-            if (language == "DE") {
-                return " (Gültig ab " + new SimpleDateFormat("d. MMMM yyy", Locale.GERMANY).format(parsedValidity) + ")"
-            } else {
-                return " (valid from " + new SimpleDateFormat("MMMM d, yyyy", Locale.US).format(parsedValidity) + ")"
-            }
-        } catch (final ParseException e) {
+            def parsedValidity = new SimpleDateFormat("yyyy/MM/dd", Locale.US).parse(validity as String)
+            return language == "DE" ? " (Gültig ab " + new SimpleDateFormat("d. MMMM yyyy", Locale.GERMANY).format(parsedValidity) + ")" : " (valid from " + new SimpleDateFormat("MMMM d, yyyy", Locale.US).format(parsedValidity) + ")"
+        } catch (ParseException e) {
             return ""
         }
     }
@@ -50,125 +44,81 @@ static def formatValidity(validity, language) {
     return ""
 }
 
-def buildPDF = rootProject.ext.languages.collect { 'pdf' + it }
-def buildHTML = rootProject.ext.languages.collect { 'html' + it }
+// Automatische Task-Erstellung für PDF & HTML
+def registerAsciiDocTask(String format, Class<?> taskType) {
+    languages.each { lang ->
+        suffixTags.each { suffix ->
+            tasks.register("${format}${lang}${suffix}", taskType) {
+                mustRunAfter includeLearningObjectives
 
-pdfThemes {
-    local 'isaqb', {
-        themeDir = '../pdf-theme/themes'
-        themeName = 'isaqb'
-    }
-}
+                jvm {
+                    jvmArgs("--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED", "--add-opens", "java.base/java.io=ALL-UNNAMED")
+                }
 
-application {
-    applicationDefaultJvmArgs = [
-            """--add-opens""", """java.base/sun.nio.ch=ALL-UNNAMED""",
-            """--add-opens""", """java.base/java.io=ALL-UNNAMED""",
-    ]
-}
+                sourceDir = file("${workDirectory}/docs/")
+                baseDir = file("${workDirectory}/docs/")
+                sources {
+                    include format == "pdf" ? "${curriculumFileName}.adoc" : ["index.adoc", "${curriculumFileName}.adoc"]
+                }
 
+                outputDir = file("${workDirectory}/build/")
 
-languages.forEach { lang ->
-    tasks.register("pdf${lang}", AsciidoctorPdfTask) {
+                def fileVersion = "${project.version.trim()}-${lang}"
 
-        mustRunAfter includeLearningObjectives
+                attributes = ['icons'                : 'font',
+                              'version-label'        : '',
+                              'revnumber'            : fileVersion,
+                              'revdate'              : versionDate,
+                              'document-version'     : "${fileVersion}-${versionDate}${formatValidity(validity, lang)}",
+                              'currentDate'          : versionDate,
+                              'release-version'      : project.version,
+                              'language'             : lang,
+                              'curriculumFileName'   : curriculumFileName,
+                              'data-uri'             : true,
+                              'allow-uri-read'       : true,
+                              'include-configuration': "tags=**;${lang};!*",
+                              'suffix'               : suffix.toString(),
+                ]
 
-        jvm {
-            jvmArgs("--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED", "--add-opens", "java.base/java.io=ALL-UNNAMED")
-        }
+                if (format == "pdf") {
+                    theme "isaqb"
+                    fontsDirs '../pdf-theme/fonts'
+                } else {
+                    attributes['stylesheet'] = '../html-theme/adoc-github.css'
+                    attributes['stylesheet-dir'] = '../html-theme'
+                }
 
-        sourceDir = new File("${workDirectory}/docs/")
-        baseDir = new File("${workDirectory}/docs/")
-        sources {
-            include "${curriculumFileName}.adoc"
-        }
+                doLast {
+                    // Falls suffix leer ist, nicht in den Dateinamen aufnehmen
+                    String suffixPart = suffix ? "-${suffix.toLowerCase()}" : ""
 
-        outputDir "${workDirectory}/build/"
-
-        theme "isaqb"
-        fontsDirs '../pdf-theme/fonts'
-        def fileVersion = project.version.trim() + "-" + lang
-
-        attributes = [
-                'icons'             : 'font',
-                'version-label'     : '',
-                'revnumber'         : fileVersion,
-                'revdate'           : versionDate,
-                'document-version'  : fileVersion + "-" + versionDate + formatValidity(validity, lang),
-                'currentDate'       : versionDate,
-                'release-version'   : project.version,
-                'language'          : lang,
-                'curriculumFileName': curriculumFileName,
-                'data-uri'          : true,
-                'allow-uri-read'    : true,
-        ]
-
-        doLast {
-            File source = new File("${workDirectory}/build/${curriculumFileName}.pdf")
-            File target = new File("${workDirectory}/build/${curriculumFileName}-${lang.toLowerCase()}.pdf")
-            source.renameTo(target)
-        }
-    }
-
-    tasks.register("html${lang}", AsciidoctorTask) {
-
-        mustRunAfter includeLearningObjectives
-
-        jvm {
-            jvmArgs("--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED", "--add-opens", "java.base/java.io=ALL-UNNAMED")
-        }
-
-        sourceDir = new File("${workDirectory}/docs/")
-        baseDir = new File("${workDirectory}/docs/")
-        sources {
-            include "index.adoc"
-            include "${curriculumFileName}.adoc"
-        }
-
-        outputDir "${workDirectory}/build/"
-
-        def fileVersion = project.version.trim() + "-" + lang
-
-        attributes = [
-                'icons'             : 'font',
-                'version-label'     : '',
-                'revnumber'         : fileVersion,
-                'revdate'           : versionDate,
-                'document-version'  : fileVersion + "-" + versionDate,
-                'currentDate'       : versionDate,
-                'release-version'   : project.version,
-                'language'          : lang,
-                'curriculumFileName': curriculumFileName,
-                'data-uri'          : true,
-                'allow-uri-read'    : true,
-                'stylesheet'        : '../html-theme/adoc-github.css',
-                'stylesheet-dir'    : '../html-theme'
-        ]
-
-        doLast {
-
-            File source = new File("${workDirectory}/build/${curriculumFileName}.html")
-            File target = new File("${workDirectory}/build/${curriculumFileName}-${lang.toLowerCase()}.html")
-            source.renameTo(target)
+                    File source = file("${workDirectory}/build/${curriculumFileName}.${format}")
+                    File target = file("${workDirectory}/build/${curriculumFileName}${suffixPart}-${lang.toLowerCase()}.${format}")
+                    source.renameTo(target)
+                }
+            }
         }
     }
 }
 
+// PDF- und HTML-Tasks registrieren
+registerAsciiDocTask("pdf", AsciidoctorPdfTask)
+registerAsciiDocTask("html", AsciidoctorTask)
 
+// Gruppierungs-Task automatisch aus bestehenden Tasks ableiten
 tasks.register('buildDocs') {
     description = 'Grouping task for generating all languages in several formats'
     group = 'documentation'
-    dependsOn includeLearningObjectives, buildPDF, buildHTML
+    dependsOn includeLearningObjectives, tasks.matching { it.name.startsWith("pdf") || it.name.startsWith("html") }
 }
 
-
+// Cleanup Task verbessert
 clean {
-    delete "build"
-    delete "${workDirectory}/build"
+    delete fileTree(dir: "${workDirectory}/build", includes: ['**/*'])
 }
 
-
+// Externe Gradle-Datei laden
 apply from: 'includeLearningObjectives.gradle'
 
-
+// Standard-Task setzen
 defaultTasks 'buildDocs'


### PR DESCRIPTION
With this feature, users can define 
`suffixTags = ["FirstTag", "SecondTag"]` 
in their build file.

They can then use `ifeval::["{suffix}" == "FirstTag"]` to render parts of the document _only_ if the tag is set. 
In addition, the resulting file will be `filename-firsttag-de.pdf` (German language set, PDF build). 
